### PR TITLE
정보 삭제 다이얼로그, 운동 결과 삭제 버튼 디자인 수정

### DIFF
--- a/app/src/main/java/kr/rabbito/homefit/screens/RoutineActivity.kt
+++ b/app/src/main/java/kr/rabbito/homefit/screens/RoutineActivity.kt
@@ -9,6 +9,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Spinner
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.room.Room
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -19,6 +20,7 @@ import kr.rabbito.homefit.data.RoutineDB
 import kr.rabbito.homefit.data.UserDB
 import kr.rabbito.homefit.databinding.ActivityRoutineBinding
 import kr.rabbito.homefit.screens.navigatorBar.SettingFragment
+import kr.rabbito.homefit.utils.setWidthPercentage
 import kr.rabbito.homefit.workout.WorkoutState
 import kotlin.properties.Delegates
 
@@ -223,12 +225,19 @@ class RoutineActivity : AppCompatActivity() {
         }
 
         binding.routineBtnDeleteSet.setOnClickListener {// 세트 삭제
-            CoroutineScope(Dispatchers.IO).launch {
-                // DB에 해당 세트 정보 삭제
-                routineDB!!.routineDAO().deleteRecord(routineId)
-            }
-            startActivity(Intent(this, RoutineListActivity::class.java))
-            finish()
+            val builder = AlertDialog.Builder(this, R.style.DeleteAlertDialog)
+            builder.setMessage("정보를 삭제하시겠습니까?")
+                .setPositiveButton("삭제") { dialog, _ ->
+                    CoroutineScope(Dispatchers.IO).launch {
+                        // DB에 해당 세트 정보 삭제
+                        routineDB!!.routineDAO().deleteRecord(routineId)
+                    }
+                    startActivity(Intent(this, RoutineListActivity::class.java))
+                    finish()
+                }.create().apply {
+                    show()
+                    setWidthPercentage(0.8)
+                }
         }
     }
 

--- a/app/src/main/java/kr/rabbito/homefit/screens/WOReportActivity.kt
+++ b/app/src/main/java/kr/rabbito/homefit/screens/WOReportActivity.kt
@@ -6,6 +6,7 @@ import android.graphics.Typeface
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.res.ResourcesCompat
 import androidx.room.Room
 import com.github.mikephil.charting.animation.Easing
@@ -29,6 +30,7 @@ import kr.rabbito.homefit.data.WorkoutDB
 import kr.rabbito.homefit.databinding.ActivityWoreportBinding
 import kr.rabbito.homefit.utils.calc.Converter.Companion.dateFormatter_ko
 import kr.rabbito.homefit.utils.calc.TimeCalc
+import kr.rabbito.homefit.utils.setWidthPercentage
 import kr.rabbito.homefit.workout.logics.getCalories
 import java.lang.Math.abs
 import java.time.LocalDate
@@ -90,14 +92,21 @@ class WOReportActivity : AppCompatActivity() {
             finish()
         }
         binding.woreportBtnDeleteReport.setOnClickListener {
-            // 운동 결과 DB삭제
-            if (workout.id != null) {
-                CoroutineScope(Dispatchers.IO).launch {
-                    workoutDB!!.workoutDAO().deleteRecord(workout.id!!)
+            val builder = AlertDialog.Builder(this, R.style.DeleteAlertDialog)
+            builder.setMessage("정보를 삭제하시겠습니까?")
+                .setPositiveButton("삭제") { dialog, _ ->
+                    // 운동 결과 DB삭제
+                    if (workout.id != null) {
+                        CoroutineScope(Dispatchers.IO).launch {
+                            workoutDB!!.workoutDAO().deleteRecord(workout.id!!)
+                        }
+                    }
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
+                }.create().apply {
+                    show()
+                    setWidthPercentage(0.8)
                 }
-            }
-            startActivity(Intent(this, MainActivity::class.java))
-            finish()
         }
 
     }

--- a/app/src/main/java/kr/rabbito/homefit/screens/WOReportActivity.kt
+++ b/app/src/main/java/kr/rabbito/homefit/screens/WOReportActivity.kt
@@ -6,6 +6,7 @@ import android.graphics.Typeface
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
+import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.res.ResourcesCompat
 import androidx.room.Room
@@ -91,6 +92,7 @@ class WOReportActivity : AppCompatActivity() {
             startActivity(Intent(this, WOHistoryActivity::class.java))
             finish()
         }
+
         binding.woreportBtnDeleteReport.setOnClickListener {
             val builder = AlertDialog.Builder(this, R.style.DeleteAlertDialog)
             builder.setMessage("정보를 삭제하시겠습니까?")
@@ -109,6 +111,23 @@ class WOReportActivity : AppCompatActivity() {
                 }
         }
 
+        binding.woreportBtnLongDeleteReport.setOnClickListener {
+            val builder = AlertDialog.Builder(this, R.style.DeleteAlertDialog)
+            builder.setMessage("정보를 삭제하시겠습니까?")
+                .setPositiveButton("삭제") { dialog, _ ->
+                    // 운동 결과 DB삭제
+                    if (workout.id != null) {
+                        CoroutineScope(Dispatchers.IO).launch {
+                            workoutDB!!.workoutDAO().deleteRecord(workout.id!!)
+                        }
+                    }
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
+                }.create().apply {
+                    show()
+                    setWidthPercentage(0.8)
+                }
+        }
     }
 
     private fun initView() {
@@ -119,10 +138,15 @@ class WOReportActivity : AppCompatActivity() {
         binding.woreportTvDate.text = workout.date!!.format(dateFormatter_ko) // 임시
 
         if (workout.id != null) {
-            binding.woreportBtnSaveReport.text = "뒤로가기"
-            binding.woreportBtnSaveReport.setOnClickListener {
-                finish()
-            }
+            binding.woreportBtnLongDeleteReport.visibility = View.VISIBLE
+
+            binding.woreportBtnSaveReport.visibility = View.GONE
+            binding.woreportBtnDeleteReport.visibility = View.GONE
+        }else{
+            binding.woreportBtnLongDeleteReport.visibility = View.GONE
+
+            binding.woreportBtnSaveReport.visibility = View.VISIBLE
+            binding.woreportBtnDeleteReport.visibility = View.VISIBLE
         }
 
         if (workout.id == null) {

--- a/app/src/main/res/layout/activity_woreport.xml
+++ b/app/src/main/res/layout/activity_woreport.xml
@@ -291,6 +291,22 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 
+    <Button
+        android:id="@+id/woreport_btn_long_delete_report"
+        android:layout_width="312dp"
+        android:layout_height="40dp"
+        android:layout_marginTop="64dp"
+        android:layout_marginBottom="32dp"
+        android:background="@drawable/init_btn_basic"
+        android:fontFamily="@font/pretendard_semibold"
+        android:includeFontPadding="false"
+        android:text="결과 삭제"
+        android:textColor="@color/white"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/woreport_cl_bot"
         android:layout_width="312dp"


### PR DESCRIPTION
1. 운동 루틴 삭제 및 운동 결과 정보 삭제 시 다이얼로그 출력
2. 운동 결과 삭제 버튼 디자인 구분(운동 후 접근: 변동 없음, 히스토리에서 접근: 결과 저장 버튼 삭제 및 결과 삭제 버튼 크기 변경)